### PR TITLE
Separate spell icons background from foreground

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,12 +86,21 @@ add_library(embedded_files OBJECT
 target_include_directories(embedded_files PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/generated/)
 
+add_library(extract_spell_icons OBJECT src/extract_spell_icons.cpp)
+target_include_directories(extract_spell_icons PUBLIC src)
+
+target_link_libraries(extract_spell_icons
+  PRIVATE
+  DvlGfx::clx2pixels
+  DvlGfx::pixels2clx)
+
 add_executable(unpack_and_minify_mpq src/unpack_and_minify_mpq.cpp)
 target_link_libraries(unpack_and_minify_mpq PRIVATE
   libmpq
   DvlGfx::cel2clx
   DvlGfx::cl22clx
   DvlGfx::pcx2clx
+  extract_spell_icons
   embedded_files)
 
 add_custom_command(

--- a/src/extract_spell_icons.cpp
+++ b/src/extract_spell_icons.cpp
@@ -1,0 +1,120 @@
+#include "extract_spell_icons.hpp"
+
+#include <cstring>
+#include <string>
+
+#include <clx2pixels.hpp>
+#include <clx_decode.hpp>
+#include <pixels2clx.hpp>
+
+namespace devilution_mpq_tools {
+
+namespace {
+
+constexpr uint8_t TransparentColor = 255;
+
+void RemoveBackground(uint8_t *pixels, unsigned width, unsigned height,
+    unsigned outerTop, unsigned outerRight, unsigned outerLeft, unsigned outerBottom,
+    const uint8_t *bg)
+{
+	// Remove top border:
+	std::memset(pixels, TransparentColor, width * outerTop);
+
+	const unsigned innerWidth = width - outerLeft - outerRight;
+	const unsigned innerHeight = height - outerBottom - outerTop;
+
+	// First round: remove borders, diff against the background.
+	// Unfortunately, this alone is not enough because the backgrounds
+	// are all slightly different (looks like noise).
+	for (unsigned y = outerTop, yEnd = outerTop + innerHeight; y < yEnd; ++y) {
+		// Remove left border:
+		std::memset(&pixels[static_cast<size_t>(y * width)],
+		    TransparentColor, outerLeft);
+		for (unsigned x = outerLeft, xEnd = outerLeft + innerWidth; x < xEnd; ++x) {
+			uint8_t &pixel = pixels[y * width + x];
+			if (bg[y * width + x] == pixel)
+				pixel = TransparentColor;
+		}
+		// Remove right border:
+		std::memset(&pixels[y * width + outerLeft + innerWidth],
+		    TransparentColor, outerRight);
+	}
+	// Remove bottom border:
+	std::memset(&pixels[static_cast<size_t>((outerTop + innerHeight) * width)],
+	    TransparentColor, width * outerBottom);
+
+	// Remove pixels that have more than 4 neighbours that are
+	// either already transparent or are in the definitely-background color range.
+	for (unsigned y = outerTop, yEnd = outerTop + innerHeight; y < yEnd; ++y) {
+		for (unsigned x = outerLeft, xEnd = outerLeft + innerWidth; x < xEnd; ++x) {
+			uint8_t &pixel = pixels[y * width + x];
+			if (pixel == TransparentColor || pixel < 192 || pixel > 205)
+				continue;
+			unsigned numTransparent = 0;
+			for (auto [dx, dy] : std::initializer_list<std::pair<int, int>> {
+			         { -1, -1 }, { -1, 0 }, { -1, 1 },
+			         { 0, -1 }, { 0, 1 },
+			         { 1, -1 }, { 1, 0 }, { 1, 1 } }) {
+				const uint8_t color = pixels[(y + dy) * width + (x + dx)];
+				if (color == TransparentColor || (color >= 192 && color < 199))
+					++numTransparent;
+			}
+			if (numTransparent > 4)
+				pixel = TransparentColor;
+		}
+	}
+}
+
+} // namespace
+
+std::string ExtractSpellIcons(std::span<const uint8_t> clxData,
+    std::vector<uint8_t> &iconBackground, std::vector<uint8_t> &iconsWithoutBackground)
+{
+	std::vector<uint8_t> pixels;
+	const std::optional<dvl_gfx::IoError> clxError = dvl_gfx::Clx2Pixels(clxData, TransparentColor, pixels);
+	if (clxError.has_value())
+		return "Failed CLX->Pixels conversion: " + clxError->message;
+
+	size_t numSprites = dvl_gfx::GetNumSpritesFromClxList(clxData.data());
+	const std::span<const uint8_t> firstSprite = dvl_gfx::GetSpriteDataFromClxList(clxData.data(), 0);
+	const unsigned width = dvl_gfx::GetClxSpriteWidth(firstSprite.data());
+	const unsigned height = dvl_gfx::GetClxSpriteHeight(firstSprite.data());
+
+	unsigned outerTop;
+	unsigned outerRight;
+	unsigned outerLeft;
+	unsigned outerBottom;
+	const size_t emptySprite = 26;
+	if (width == 37 && height == 38) {
+		// `spelli2`, the last sprite is unused
+		--numSprites;
+		outerLeft = outerBottom = 1;
+		outerRight = outerTop = 2;
+	} else if (width == 56 && height == 56) {
+		// `spelicon`, the last 9 sprites are overlays, unused in DevilutionX.
+		numSprites -= 9;
+		outerLeft = outerBottom = 5;
+		outerRight = outerTop = 4;
+	} else {
+		return "Unsupported icon size";
+	}
+
+	dvl_gfx::Pixels2Clx(&pixels[emptySprite * width * height],
+	    /*pitch=*/width, width, /*frameHeight=*/height, /*numFrames=*/1,
+	    TransparentColor, iconBackground);
+
+	for (size_t frame = 0; frame < numSprites; ++frame) {
+		if (frame == emptySprite)
+			continue;
+		RemoveBackground(&pixels[frame * width * height], width, height,
+		    outerTop, outerRight, outerBottom, outerLeft, &pixels[emptySprite * width * height]);
+	}
+	std::memset(&pixels[emptySprite * width * height], TransparentColor, width * height);
+
+	dvl_gfx::Pixels2Clx(pixels.data(),
+	    /*pitch=*/width, width, /*frameHeight=*/height, numSprites,
+	    TransparentColor, iconsWithoutBackground);
+	return "";
+}
+
+} // namespace devilution_mpq_tools

--- a/src/extract_spell_icons.hpp
+++ b/src/extract_spell_icons.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace devilution_mpq_tools {
+
+std::string ExtractSpellIcons(std::span<const uint8_t> clxData,
+    std::vector<uint8_t> &iconBackground, std::vector<uint8_t> &iconsWithoutBackground);
+
+} // namespace devilution_mpq_tools

--- a/third_party/dvl_gfx/CMakeLists.txt
+++ b/third_party/dvl_gfx/CMakeLists.txt
@@ -3,7 +3,7 @@ include(functions/FetchContent_MakeAvailableExcludeFromAll)
 set(ENABLE_INSTALL OFF)
 FetchContent_Declare(
   dvl_gfx
-  URL https://github.com/diasurgical/devilutionx-graphics-tools/archive/6f7e8c73df255d15617e5cb6ae088667b387207b.tar.gz
-  URL_HASH MD5=47717c8d6d4bab5c19b44717fc40f798
+  URL https://github.com/diasurgical/devilutionx-graphics-tools/archive/0c772ebf497ef9d4aa82b4339913babd535e9bb5.tar.gz
+  URL_HASH MD5=2a9bb407f81badc047d75899db9228f2
 )
 FetchContent_MakeAvailableExcludeFromAll(dvl_gfx)


### PR DESCRIPTION
Saves ~120 KiB with Hellfire icons (200 KiB -> 81 KiB).

Images without backgrounds:
Large: ![spelicon_fg_clx](https://user-images.githubusercontent.com/216339/200957687-008693b8-3bb3-4bba-aa01-b883f0956cd5.png)
Small: ![spelli2_fg_clx](https://user-images.githubusercontent.com/216339/200957693-0956e798-3920-497c-aacf-d02236a92694.png)

Refs https://github.com/diasurgical/devilutionX/issues/5470