### PR TITLE
Rename tool and enhance README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,67 @@
-# DevilutionX MPQ tools
+# DevilutionX Asset Optimizer
+
+A specialized utility suite designed to process and optimize game assets for **DevilutionX**, specifically tailored to reduce memory usage on constrained devices (such as retro consoles, mobile devices, and older hardware).
+
+> [!IMPORTANT]
+> **Not a General Extraction Tool:** This utility is designed to **convert and minify** assets into optimized formats (such as CLX) for use with DevilutionX. If you want to extract original files for the purpose of modding, please use a standard MPQ editor like `smpq` or [MPQ Editor](http://www.zezula.net/en/mpq/download.html) instead.
+
+---
 
 ## `unpack_and_minify_mpq`
 
-Unpacks an MPQ and minifies its assets.
+This utility unpacks an MPQ archive and transforms its contents into highly efficient formats. By converting assets, it significantly lowers the RAM overhead required by the game engine, making it ideal for platforms with limited resources.
 
-All graphics assets are converted to CLX.
+### Key Features
+
+* **Memory Optimization:** Specifically tuned to help DevilutionX run on memory-constrained devices.
+* **CLX Conversion:** Automatically converts graphical assets to the optimized CLX format.
+* **Asset Minification:** Strips unnecessary data and reduces file footprints.
+* **Audio Processing (Planned):** Support for WAV to MP3 conversion via the `--mp3` flag is currently in development.
+
+---
+
+## Getting Started
+
+### Installation
+
+**Windows**
+
+1. Download the latest binary from the [Releases Page](https://github.com/diasurgical/devilutionx-mpq-tools/releases).
+2. Place the binary in the same directory as your `.mpq` files.
+
+**Linux / macOS**
+Please follow the [Build from Source](https://www.google.com/search?q=%23build-from-source) instructions below.
 
 ### Usage
 
-Simply drop the binary into the directory with the MPQs and run it.
+Run the tool directly from your terminal or command prompt:
 
-Alternatively, run `unpack_and_minify_mpq --help` to see the list of options.
+```bash
+./unpack_and_minify_mpq
 
-If `--mp3` is passed, audio is converted from WAV to MP3. Not implemented yet.
+```
 
-### Install
+For advanced configuration and a full list of flags, use:
 
-On Windows, download the latest release from https://github.com/diasurgical/devilutionx-mpq-tools/releases.
+```bash
+./unpack_and_minify_mpq --help
 
-On other OSes, build and install from source (see below).
+```
 
-### Build from source
+---
+
+## Build from Source
+
+Ensure you have **CMake** and **Ninja** installed on your system.
+
+**1. Configure and Build**
 
 ```bash
 cmake -S. -Bbuild-rel -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
 cmake --build build-rel -j $(getconf _NPROCESSORS_ONLN)
 ```
 
-To install the built binary:
+**2. Install**
 
 ```bash
 sudo cmake --install build-rel


### PR DESCRIPTION
This is mainly to try and stop people from getting confused that there are no .cl2 files after they try to use this tool to just extract files from the MPQ files.